### PR TITLE
Add Summate Black Friday Deal

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ Get a clean, error-free transcript with improved grammar & punctuation. | 50% OF
 
 #### 💸 (51% OFF) [Codetoflow](http://codetoflow.com/?ref=black_friday_deals_by_MaciejZimoch) - Code to Flow enables you to Visualize, Analyze, and Understand Your Code by turning it into Interactive Flowcharts with AI. 51% off on all plans. Code: **`BLF51`** (Valid till 27th Nov, 2024)
 
-#### 💰 (50% OFF) [PDFPeer](https://pdfpeer.com) - Turn your PDF to AI with PDFPeer! From study materials to bank statements, PDFPeer makes it easy to chat with your documents. Get 50% OFF with promo code **BF50**. 
+#### 💰 (50% OFF) [PDFPeer](https://pdfpeer.com) - Turn your PDF to AI with PDFPeer! From study materials to bank statements, PDFPeer makes it easy to chat with your documents. Get 50% OFF with promo code **BF50**.
+
+#### 💸 (50% OFF) [Summate](https://summate.io) - AI-powered digest that turns newsletters, YouTube, and 50+ sources into personalized summaries. 2 hours → 10 minutes. Code: SUMMATEBF25 = 50% off (Valid till 5th Dec)
 
 -------------
 


### PR DESCRIPTION
## Summary
Add Summate.io to the AI section of the Black Friday deals list.

## Deal Details
- **Product**: Summate - AI-powered digest service
- **Description**: Turns newsletters, YouTube, and 50+ sources into personalized summaries (2 hours → 10 minutes)
- **Discount**: 50% off
- **Code**: SUMMATEBF25
- **Normal Price**: $20/mo (annual) / $30/mo (monthly)
- **BF Price**: $10/mo (annual) / $15/mo (monthly)
- **Valid Until**: December 5, 2025

## Changes
- Added entry to the Apps > AI section
- Followed existing formatting conventions
- Included discount code and expiry date

🤖 Generated with [Claude Code](https://claude.com/claude-code)